### PR TITLE
Upgrade `logzio-to-trivy` to v0.2.3

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "weekly"

--- a/.github/workflows/upload-docker.yaml
+++ b/.github/workflows/upload-docker.yaml
@@ -9,18 +9,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Ensure full git history is checked out
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -32,7 +32,7 @@ jobs:
           echo "VERSION=${{ github.event.release.tag_name }}"
 
       - name: Build and push version to Docker Hub
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -47,18 +47,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Ensure full git history is checked out
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Public ECR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: public.ecr.aws
           username: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -73,7 +73,7 @@ jobs:
           echo "VERSION=${{ github.event.release.tag_name }}"
 
       - name: Build and push version to Public ECR
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.0a7-slim
+FROM python:3.12.5-slim
 
 # Install git
 RUN apt-get update && apt-get install -y git

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ To use it, see Logz.io's [logzio-trivy Helm Chart](https://github.com/logzio/log
 
 
 ## Changelog:
-
+- **0.2.3**:
+  - Upgrade python version to 3.12.5.
+  - Re-build image to include the latest version of git(CVE-2024-32002).
+- **0.2.2**:
+  - Added 'user-agent' header for telemetry data.
 - **0.2.1**:
   - Bump base docker image version.
   - Bump packages in requirements.


### PR DESCRIPTION
- Update release workflow
- Add dependabot
- Upgrade python version to 3.12.5.
- Re-build image to include the latest version of git(CVE-2024-32002).
